### PR TITLE
Scrollable calendar - vertically and horizontally - height 100% broken after adding event

### DIFF
--- a/angular17/package.json
+++ b/angular17/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "./monorepo-hack.cjs && ng serve",
-    "build": "./monorepo-hack.cjs && ng build",
+    "start": "ng serve",
+    "build": "ng build",
     "watch": "./monorepo-hack.cjs && ng build --watch --configuration development",
     "xxxtest": "./monorepo-hack.cjs && ng test --watch=false --browsers ChromeHeadless",
     "xxxtest:dev": "./monorepo-hack.cjs && ng test",
@@ -25,7 +25,10 @@
     "@fullcalendar/daygrid": "^6.1.10",
     "@fullcalendar/interaction": "^6.1.10",
     "@fullcalendar/list": "^6.1.10",
+    "@fullcalendar/resource-timegrid": "^6.1.11",
+    "@fullcalendar/resource-timeline": "^6.1.11",
     "@fullcalendar/timegrid": "^6.1.10",
+    "@fullcalendar/scrollgrid": "6.1.11",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.2"

--- a/angular17/src/app/app.component.css
+++ b/angular17/src/app/app.component.css
@@ -38,10 +38,9 @@ b { /* used for event dates/times */
 
 .demo-app-main {
   flex-grow: 1;
-  padding: 3em;
+  padding: 1em;
 }
 
 .fc { /* the calendar root */
-  max-width: 1100px;
   margin: 0 auto;
 }

--- a/angular17/src/app/app.component.html
+++ b/angular17/src/app/app.component.html
@@ -31,7 +31,7 @@
       </label>
     </div>
     <div class='demo-app-sidebar-section'>
-      <h2>All Events ({{currentEvents.length}})</h2>
+      <h2>All Events ({{currentEvents().length}})</h2>
       <ul>
         <li *ngFor='let event of currentEvents()'>
           <b>{{event.startStr}}</b>

--- a/angular17/src/app/app.component.ts
+++ b/angular17/src/app/app.component.ts
@@ -7,6 +7,8 @@ import interactionPlugin from '@fullcalendar/interaction';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import listPlugin from '@fullcalendar/list';
+import resourceTimeGridPlugin from '@fullcalendar/resource-timegrid';
+import scrollGridPlugin from '@fullcalendar/scrollgrid';
 import { INITIAL_EVENTS, createEventId } from './event-utils';
 
 @Component({
@@ -24,22 +26,57 @@ export class AppComponent {
       dayGridPlugin,
       timeGridPlugin,
       listPlugin,
+      // resourceTimelinePlugin,
+      resourceTimeGridPlugin,
+      scrollGridPlugin,
     ],
     headerToolbar: {
       left: 'prev,next today',
       center: 'title',
-      right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek'
+      right: 'resourceTimeGrid,dayGridMonth,timeGridWeek,timeGridDay,listWeek'
     },
-    initialView: 'dayGridMonth',
+    initialView: 'resourceTimeGridDay',
     initialEvents: INITIAL_EVENTS, // alternatively, use the `events` setting to fetch from a feed
-    weekends: true,
-    editable: true,
-    selectable: true,
-    selectMirror: true,
-    dayMaxEvents: true,
-    select: this.handleDateSelect.bind(this),
-    eventClick: this.handleEventClick.bind(this),
-    eventsSet: this.handleEvents.bind(this)
+    // weekends: true,
+    // editable: true,
+    // selectable: true,
+    // selectMirror: true,
+    // dayMaxEvents: true,
+    dayMinWidth: 300, // only works if too many resources, otherwise columns get equal split
+    // select: this.handleDateSelect.bind(this),
+    // eventClick: this.handleEventClick.bind(this),
+    // eventsSet: this.handleEvents.bind(this),
+    // resourceAreaWidth: '30%', does not work
+    resources: [ // Define your resources here
+      { id: 'a', title: 'Resource A' },
+      { id: 'b', title: 'Resource B' },
+      { id: 'c', title: 'Resource C' },
+      { id: 'd', title: 'Resource D' },
+      { id: 'e', title: 'Resource E' },
+      { id: 'f', title: 'Resource F' },
+      { id: 'g', title: 'Resource G' },
+      { id: 'h', title: 'Resource H' },
+      { id: 'i', title: 'Resource I' },
+      { id: 'j', title: 'Resource J' },
+      { id: 'k', title: 'Resource K' },
+      { id: 'l', title: 'Resource L' },
+      { id: 'm', title: 'Resource M' },
+      { id: 'n', title: 'Resource N' },
+      { id: 'o', title: 'Resource O' },
+      { id: 'p', title: 'Resource P' },
+      { id: 'q', title: 'Resource Q' },
+      { id: 'r', title: 'Resource R' },
+      { id: 's', title: 'Resource S' },
+      { id: 't', title: 'Resource T' },
+      { id: 'u', title: 'Resource U' },
+      { id: 'v', title: 'Resource V' },
+      { id: 'w', title: 'Resource W' },
+      { id: 'x', title: 'Resource X' },
+      { id: 'y', title: 'Resource Y' },
+      { id: 'z', title: 'Resource Z' }
+
+      // Add more resources as needed
+    ],
     /* you can update a remote database when these fire:
     eventAdd:
     eventChange:

--- a/angular17/src/app/app.component.ts
+++ b/angular17/src/app/app.component.ts
@@ -37,16 +37,16 @@ export class AppComponent {
     },
     initialView: 'resourceTimeGridDay',
     initialEvents: INITIAL_EVENTS, // alternatively, use the `events` setting to fetch from a feed
+    height: '100%', // TODO: works until an event is added, then it's ignored
     // weekends: true,
-    // editable: true,
-    // selectable: true,
-    // selectMirror: true,
+    editable: true,
+    selectable: true,
+    selectMirror: true,
     // dayMaxEvents: true,
     dayMinWidth: 300, // only works if too many resources, otherwise columns get equal split
-    // select: this.handleDateSelect.bind(this),
-    // eventClick: this.handleEventClick.bind(this),
-    // eventsSet: this.handleEvents.bind(this),
-    // resourceAreaWidth: '30%', does not work
+    select: this.handleDateSelect.bind(this),
+    eventClick: this.handleEventClick.bind(this),
+    eventsSet: this.handleEvents.bind(this),
     resources: [ // Define your resources here
       { id: 'a', title: 'Resource A' },
       { id: 'b', title: 'Resource B' },
@@ -103,7 +103,13 @@ export class AppComponent {
     const title = prompt('Please enter a new title for your event');
     const calendarApi = selectInfo.view.calendar;
 
+    console.log(selectInfo);
     calendarApi.unselect(); // clear date selection
+
+    let resourceId = '';
+    if (selectInfo.resource) { // TODO: type for selectInfo that has resource ?
+      resourceId = selectInfo.resource.id;
+    }
 
     if (title) {
       calendarApi.addEvent({
@@ -111,8 +117,12 @@ export class AppComponent {
         title,
         start: selectInfo.startStr,
         end: selectInfo.endStr,
-        allDay: selectInfo.allDay
+        allDay: selectInfo.allDay,
+        resourceId: resourceId,
       });
+
+      // TODO: below line does not do anything
+      // calendarApi.setOption('height', '100%'); // workaround for height not being set
     }
   }
 


### PR DESCRIPTION
Adding an event breaks height: 100% behavior, any view, resource or not

Before adding an event - notice no page scrollbar:
![image](https://github.com/vzakharov-rxnt/fullcalendar-examples/assets/85562318/4dbccf8c-0801-47d2-877a-600b5d5b2424)

After adding an event - page scrollbar is added:
![image](https://github.com/vzakharov-rxnt/fullcalendar-examples/assets/85562318/ebcdb66f-11c0-4091-968f-bb015434fa5f)